### PR TITLE
Add super simple version of website media

### DIFF
--- a/screen/index.html
+++ b/screen/index.html
@@ -3,8 +3,8 @@
     <head>
         <meta charset="UTF-8">
         <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000">
-        <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000; frame-src * data: blob: ">
+        <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000; frame-src * data: blob: ">
         <link rel = "stylesheet" type = "text/css" href = "css/main.css"/>
         <title>Screencrash [Screen]</title>
     </head>

--- a/screen/model/commandrouter.js
+++ b/screen/model/commandrouter.js
@@ -1,6 +1,7 @@
 
 const VideoHandler = require("./media/videohandler");
 const ImageHandler = require("./media/imagehandler");
+const WebsiteHandler = require("./media/websitehandler");
 
 module.exports = class CommandRouter {
 
@@ -41,8 +42,9 @@ module.exports = class CommandRouter {
 
     createHandlerFromType(entityId, type){
         switch(type){
-            case "video": return new VideoHandler(entityId, this.dom);
-            case "image": return new ImageHandler(entityId, this.dom);
+            case "video":   return new VideoHandler(entityId, this.dom);
+            case "image":   return new ImageHandler(entityId, this.dom);
+            case "website": return new WebsiteHandler(entityId, this.dom);
             default:
                 throw `Unsupported media type ${type}`;
         }

--- a/screen/model/media/websitehandler.js
+++ b/screen/model/media/websitehandler.js
@@ -1,0 +1,28 @@
+
+const MediaHandler = require('./mediahandler');
+
+module.exports = class WebsiteHandler extends MediaHandler {
+
+    constructor(id, dom){
+        super(id, dom);
+    }
+
+    init(createMessage){
+        super.init(createMessage);
+
+        this.uiWrapper.innerHTML = `
+            <iframe id = "website-frame-${this.id}" class = "website-frame"
+                    src = "${createMessage.resource}"
+                    frameborder = "0" height="100%" width="100%" scrolling = "no">
+            </iframe>
+        `;
+    }
+
+    handleMessage(msg){
+
+        switch(msg.command){
+            default:
+                super.handleMessage(msg);
+        }
+    }
+}


### PR DESCRIPTION
Can be added just as with an image or video. For example, if using dummy_core you can submit the following command:
```{"command": "create", "channel": 1, "entity_id": 1337, "type": "website", "resource": "https://matzlarsson.se", "visible": true}```