### PR TITLE
Tweaks to connect to a real Core

### DIFF
--- a/screen/index.html
+++ b/screen/index.html
@@ -2,9 +2,6 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000; frame-src * data: blob: ">
-        <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:3000; frame-src * data: blob: ">
         <link rel = "stylesheet" type = "text/css" href = "css/main.css"/>
         <title>Screencrash [Screen]</title>
     </head>

--- a/screen/model/coreconnection.js
+++ b/screen/model/coreconnection.js
@@ -64,14 +64,14 @@ module.exports = class CoreConnection {
     _getAnnounceMessage() {
         return {
             type: 'announce',
-            component: 'screen',
+            client: 'screen',
             channel: 1
         };
     }
 
     _getHeartbeatMessage() {
         return {
-            type: 'heartbeat',
+            messageType: 'heartbeat',
             component: 'screen',
             channel: 1
         };

--- a/screen/renderer.js
+++ b/screen/renderer.js
@@ -6,7 +6,7 @@ const commandRouter = new CommandRouter(document);
 // Init connection to core
 const Connection = require('./model/coreconnection');
 // eslint-disable-next-line no-unused-vars
-const coreConnection = new Connection('ws://localhost:3000/', commandRouter.handleMessage.bind(commandRouter));
+const coreConnection = new Connection(`ws://${process.env.CORE}/`, commandRouter.handleMessage.bind(commandRouter));
 
 // TODO: Do we need to save a reference to the core connection? It seems to handle itself rather nicely already.
 //       I left it there for future potential features with replacing core address etc.


### PR DESCRIPTION
- Remove Content-Security-Policy stuff. It's not really relevant
  in our case.
- Allow specifying Core with the environment variable CORE
- Change some message content to better align with what Core
  expects.