### PR TITLE
Add more commands for inventory

### DIFF
--- a/inventory/communication.js
+++ b/inventory/communication.js
@@ -32,6 +32,7 @@ class CommunicationModel {
         this.inventory.addEventListener("achievement", this._sendAchievementUpdate.bind(this));
         this.inventory.addEventListener("achievements", this._sendAchievementsUpdate.bind(this));
         this.inventory.addEventListener("achievement_reached", this._sendAchievementReachedUpdate.bind(this));
+        this.inventory.addEventListener("items_visibility", this._sendItemsVisibilityUpdate.bind(this));
     }
 
     _setupCoreSocket() {
@@ -59,6 +60,10 @@ class CommunicationModel {
 
     _sendItemsUpdate() {
         this._sendToAll({ messageType: "items", items: this.inventory.getCurrentItems() });
+    }
+
+    _sendItemsVisibilityUpdate() {
+        this._sendToAll({ messageType: "items_visibility", visible: this.inventory.getItemsSectionVisibility() });
     }
 
     _sendMoneyUpdate() {
@@ -101,6 +106,10 @@ class CommunicationModel {
         sock.send(JSON.stringify({
             messageType: "configuration",
             data: this.inventory.getStaticData()
+        }));
+        sock.send(JSON.stringify({
+            messageType: "items_visibility",
+            visible: this.inventory.getItemsSectionVisibility()
         }));
         sock.send(JSON.stringify({
             messageType: "items",
@@ -208,6 +217,10 @@ class CommunicationModel {
                     break;
                 case "change_money":
                     this.inventory.changeMoney(message.amount);
+                    break;
+                case "set_items_visibility":
+                    // Use to hide items section and only show achievements section
+                    this.inventory.setItemsSectionVisibility(message.visible);
                     break;
                 case "set_currency":
                     this.inventory.setCurrency(message.currency);

--- a/inventory/communication.js
+++ b/inventory/communication.js
@@ -193,7 +193,15 @@ class CommunicationModel {
                     this.inventory.sell(message.item);
                     break;
                 case "add":
-                    this.inventory.add(message.item);
+                    if (message.item) {
+                        this.inventory.add(message.item);
+                    } else if (message.items) {
+                        message.items.split(",").forEach((item) => {
+                            this.inventory.add(item);
+                        });
+                    } else {
+                        console.log("No input item given to add command");
+                    }
                     break;
                 case "remove":
                     this.inventory.remove(message.item);

--- a/inventory/inventory.js
+++ b/inventory/inventory.js
@@ -17,6 +17,7 @@ class Inventory extends EventTarget {
         this.staticData = { items: [], achievements: {} };
         this.money = 0;
         this.currency = "money";
+        this.itemsSectionVisibility = true;
         this.items = [];
         this.achievements = [];
         this.getAchievement = this.getAchievement.bind(this);
@@ -76,6 +77,10 @@ class Inventory extends EventTarget {
 
     getCurrency() {
         return this.currency;
+    }
+
+    getItemsSectionVisibility() {
+        return this.itemsSectionVisibility;
     }
 
     getAvailableItems() {
@@ -141,6 +146,13 @@ class Inventory extends EventTarget {
     setCurrency(currency) {
         if (currency !== undefined && currency !== null) {
             this.currency = currency;
+        }
+    }
+
+    setItemsSectionVisibility(visible) {
+        if (visible !== undefined && visible !== null && this.itemsSectionVisibility !== visible) {
+            this.itemsSectionVisibility = visible;
+            this.dispatchEvent(new InventoryEvent("items_visibility", visible));
         }
     }
 

--- a/inventory/views/main.hbs
+++ b/inventory/views/main.hbs
@@ -82,6 +82,9 @@
 			case "money":
 				updateMoney(msg.money);
 				break;
+			case "items_visibility":
+				updateInventoryVisibility(msg.visible);
+				break;
 			default:
 				console.log(`Ignoring unhandled message type ${msg.messageType}`);
 		}
@@ -138,5 +141,9 @@
 		container.appendChild(achievementNode);
 		achievementNode.className += " visible";
 		setTimeout(function(){ container.removeChild(achievementNode); }, 10000);
+	}
+
+	function updateInventoryVisibility(visible) {
+		document.getElementById("inventory").style.display = (visible ? "block" : "none");
 	}
 </script>


### PR DESCRIPTION
Added/Edited two commands:
  - `add` now takes either a param `item` or a param `items`. This allows to add multiple items at the same time.
  - `set_items_visibility` takes a boolean parameter which determines whether to show the items section of the inventory or not. Hiding this section can be good when enabling achievements but still don't want to cover too much of the screen.