### PR TITLE
Add transition effects for position and size on visual elements

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -55,3 +55,36 @@ audio.audio-media {
     width: 100px;
     visibility: hidden;
 }
+
+
+/* Animations */
+.animation-shake {
+    animation: shake 0.5s;
+    animation-iteration-count: infinite;
+}
+
+@keyframes shake {
+    0% { transform: translate(1px, 1px) rotate(0deg); }
+    10% { transform: translate(-1px, -2px) rotate(-1deg); }
+    20% { transform: translate(-3px, 0px) rotate(1deg); }
+    30% { transform: translate(3px, 2px) rotate(0deg); }
+    40% { transform: translate(1px, -1px) rotate(1deg); }
+    50% { transform: translate(-1px, 2px) rotate(-1deg); }
+    60% { transform: translate(-3px, 1px) rotate(0deg); }
+    70% { transform: translate(3px, 1px) rotate(-1deg); }
+    80% { transform: translate(-1px, -1px) rotate(1deg); }
+    90% { transform: translate(1px, 2px) rotate(0deg); }
+    100% { transform: translate(1px, -2px) rotate(-1deg); }
+}
+
+.animation-nod {
+    animation: nod 1s;
+    animation-iteration-count: infinite;
+  }
+  
+  @keyframes nod {
+    0% { transform: translate(0px, 0px); }
+    20% { transform: translate(0px, 10px); }
+    80% { transform: translate(0px, -10px); }
+    100% { transform: translate(0px, 0px); }
+  }

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -80,11 +80,21 @@ audio.audio-media {
 .animation-nod {
     animation: nod 1s;
     animation-iteration-count: infinite;
-  }
+}
   
-  @keyframes nod {
+@keyframes nod {
     0% { transform: translate(0px, 0px); }
     20% { transform: translate(0px, 10px); }
     80% { transform: translate(0px, -10px); }
     100% { transform: translate(0px, 0px); }
-  }
+}
+
+.animation-spin {
+    animation: spin 1s;
+    animation-iteration-count: infinite;
+}
+
+@keyframes spin {
+    from {transform:rotate(0deg);}
+    to {transform:rotate(360deg);}
+}

--- a/media/model/media/visualhandler.js
+++ b/media/model/media/visualhandler.js
@@ -3,6 +3,7 @@ const MediaHandler = require('./mediahandler');
 const $ = require('jquery');
 
 const { addClass, removeClass, hasClass } = require('../domutils');
+const AVAILABLE_ANIMATIONS = ['shake', 'nod'];
 
 module.exports = class VisualHandler extends MediaHandler {
 
@@ -28,11 +29,18 @@ module.exports = class VisualHandler extends MediaHandler {
             // Height
             const transitionHeight = this._createCssTransition([msg.transitions.height, msg.transitions.size], 'height');
             if (transitionHeight) cssTransitions.push(transitionHeight);
+            // Opacity
+            const transitionOpacity = this._createCssTransition([msg.transitions.opacity], 'opacity');
+            if (transitionOpacity) cssTransitions.push(transitionOpacity);
 
             const fullCss = cssTransitions.join(', ');
             if (fullCss) {
                 this.uiWrapper.style.transition = fullCss;
             }
+        }
+
+        if (msg.animation && AVAILABLE_ANIMATIONS.includes(msg.animation)) {
+            this.uiWrapper.className += ` animation-${msg.animation}`;
         }
 
         this.setViewport(msg.x, msg.y, msg.width, msg.height, msg.usePercentage);
@@ -54,8 +62,9 @@ module.exports = class VisualHandler extends MediaHandler {
         console.log(JSON.stringify({ configs, property }));
         const duration = configs.reduceRight((prev, curr) => curr && curr.duration != null ? curr.duration : prev, null);
         const type = configs.reduceRight((prev, curr) => curr && curr.type != null ? curr.type : prev, null);
-        if (duration || type) {
-            return `${property} ${duration || 1}s ${type || 'ease'}`;
+        const delay = configs.reduceRight((prev, curr) => curr && curr.delay != null ? curr.delay : prev, null);
+        if (duration || type || delay) {
+            return `${property} ${duration || 1}s ${type || 'ease'} ${delay || 0}s`;
         }
         return '';
     }

--- a/media/model/media/visualhandler.js
+++ b/media/model/media/visualhandler.js
@@ -59,7 +59,6 @@ module.exports = class VisualHandler extends MediaHandler {
     }
 
     _createCssTransition(configs, property) {
-        console.log(JSON.stringify({ configs, property }));
         const duration = configs.reduceRight((prev, curr) => curr && curr.duration != null ? curr.duration : prev, null);
         const type = configs.reduceRight((prev, curr) => curr && curr.type != null ? curr.type : prev, null);
         const delay = configs.reduceRight((prev, curr) => curr && curr.delay != null ? curr.delay : prev, null);

--- a/media/model/media/visualhandler.js
+++ b/media/model/media/visualhandler.js
@@ -14,6 +14,27 @@ module.exports = class VisualHandler extends MediaHandler {
     init(msg, resourcesPath) {
         super.init(msg, resourcesPath);
 
+        if (msg.transitions) {
+            const cssTransitions = [];
+            // Movement along X-axis
+            const transitionMoveX = msg.transitions.move_x || msg.transitions.move;
+            if (transitionMoveX) cssTransitions.push(`top ${transitionMoveX}s`);
+            // Movement along Y-axis
+            const transitionMoveY = msg.transitions.move_y || msg.transitions.move;
+            if (transitionMoveY) cssTransitions.push(`left ${transitionMoveY}s`);
+            // Width
+            const transitionWidth = msg.transitions.width || msg.transitions.size;
+            if (transitionWidth) cssTransitions.push(`width ${transitionWidth}s`);
+            // Height
+            const transitionHeight = msg.transitions.height || msg.transitions.size;
+            if (transitionHeight) cssTransitions.push(`height ${transitionHeight}s`);
+
+            const fullCss = cssTransitions.join(', ');
+            if (fullCss) {
+                this.uiWrapper.style.transition = fullCss;
+            }
+        }
+
         this.setViewport(msg.x, msg.y, msg.width, msg.height, msg.usePercentage);
 
         if (msg.visible) {

--- a/media/model/media/visualhandler.js
+++ b/media/model/media/visualhandler.js
@@ -3,7 +3,7 @@ const MediaHandler = require('./mediahandler');
 const $ = require('jquery');
 
 const { addClass, removeClass, hasClass } = require('../domutils');
-const AVAILABLE_ANIMATIONS = ['shake', 'nod'];
+const AVAILABLE_ANIMATIONS = ['shake', 'nod', 'spin'];
 
 module.exports = class VisualHandler extends MediaHandler {
 

--- a/media/model/media/visualhandler.js
+++ b/media/model/media/visualhandler.js
@@ -17,17 +17,17 @@ module.exports = class VisualHandler extends MediaHandler {
         if (msg.transitions) {
             const cssTransitions = [];
             // Movement along X-axis
-            const transitionMoveX = msg.transitions.move_x || msg.transitions.move;
-            if (transitionMoveX) cssTransitions.push(`top ${transitionMoveX}s`);
+            const transitionMoveX = this._createCssTransition([msg.transitions.move_x, msg.transitions.move], 'left');
+            if (transitionMoveX) cssTransitions.push(transitionMoveX);
             // Movement along Y-axis
-            const transitionMoveY = msg.transitions.move_y || msg.transitions.move;
-            if (transitionMoveY) cssTransitions.push(`left ${transitionMoveY}s`);
+            const transitionMoveY = this._createCssTransition([msg.transitions.move_y, msg.transitions.move], 'top');
+            if (transitionMoveY) cssTransitions.push(transitionMoveY);
             // Width
-            const transitionWidth = msg.transitions.width || msg.transitions.size;
-            if (transitionWidth) cssTransitions.push(`width ${transitionWidth}s`);
+            const transitionWidth = this._createCssTransition([msg.transitions.width, msg.transitions.size], 'width');
+            if (transitionWidth) cssTransitions.push(transitionWidth);
             // Height
-            const transitionHeight = msg.transitions.height || msg.transitions.size;
-            if (transitionHeight) cssTransitions.push(`height ${transitionHeight}s`);
+            const transitionHeight = this._createCssTransition([msg.transitions.height, msg.transitions.size], 'height');
+            if (transitionHeight) cssTransitions.push(transitionHeight);
 
             const fullCss = cssTransitions.join(', ');
             if (fullCss) {
@@ -48,6 +48,16 @@ module.exports = class VisualHandler extends MediaHandler {
         if (typeof msg.layer === 'number') {
             this.setLayer(msg.layer);
         }
+    }
+
+    _createCssTransition(configs, property) {
+        console.log(JSON.stringify({ configs, property }));
+        const duration = configs.reduceRight((prev, curr) => curr && curr.duration != null ? curr.duration : prev, null);
+        const type = configs.reduceRight((prev, curr) => curr && curr.type != null ? curr.type : prev, null);
+        if (duration || type) {
+            return `${property} ${duration || 1}s ${type || 'ease'}`;
+        }
+        return '';
     }
 
     getRegularUpdateState() {


### PR DESCRIPTION
Visual elements (image, video, web) can now be animated by setting the `transitions` property on creation. Too keep it simple, elements cannot change transition settings after creation.