### PR TITLE
Add option to not destroy video when finished

### DIFF
--- a/media/model/media/videohandler.js
+++ b/media/model/media/videohandler.js
@@ -195,6 +195,8 @@ module.exports = class VideoHandler extends VisualHandler {
         this.finalFadeOutStarted = false;
         this.fadeStartVolume = 0;
 
+        this.destroyOnEnd = createMessage.destroyOnEnd ?? true;
+
         // Set name of this handler
         this.name = path.parse(createMessage.asset).name;
         if (createMessage.displayName) {
@@ -384,7 +386,9 @@ module.exports = class VideoHandler extends VisualHandler {
     }
 
     onEnded() {
-        this.destroy();
+        if (this.destroyOnEnd) {
+            this.destroy();
+        }
     }
 
     onLoadedData() {


### PR DESCRIPTION
This will keep displaying the last frame of the video. This is an alternative to creating an image as the new background, where the colors may be slightly different.